### PR TITLE
remove --restart switch from pending-changes apply

### DIFF
--- a/config/tableau-init-configure.sh
+++ b/config/tableau-init-configure.sh
@@ -47,7 +47,7 @@ else
     log settings import done
 
     log pending-changes apply
-    su tsm -c "sudo /opt/tableau/tableau_server/packages/customer-bin.${TABLEAU_SERVER_DATA_DIR_VERSION}/tsm pending-changes apply --restart" 2>&1 1>> /var/log/tableau_docker.log
+    su tsm -c "sudo /opt/tableau/tableau_server/packages/customer-bin.${TABLEAU_SERVER_DATA_DIR_VERSION}/tsm pending-changes apply" 2>&1 1>> /var/log/tableau_docker.log
     log penging-changes apply done
 
     log initalize server


### PR DESCRIPTION
With the 2018.2 release, the `--restart` flag does not work successfully. This PR removes that switch.